### PR TITLE
[FLINK-38465]  Continue on error and metadata column support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .gitignore.swp
 .project
 .settings
+.DS_Store
 /.java-version
 .eslintcache
 .cache

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/clients/PollingClient.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/clients/PollingClient.java
@@ -17,21 +17,20 @@
 
 package org.apache.flink.connector.http.clients;
 
+import org.apache.flink.connector.http.table.lookup.HttpRowDataWrapper;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.FunctionContext;
 
-import java.util.Collection;
-
 /** A client that is used to get enrichment data from external component. */
-public interface PollingClient<T> {
+public interface PollingClient {
 
     /**
      * Gets enrichment data from external component using provided lookup arguments.
      *
      * @param lookupRow A {@link RowData} containing request parameters.
-     * @return an optional result of data lookup.
+     * @return an optional result of data lookup with http information.
      */
-    Collection<T> pull(RowData lookupRow);
+    HttpRowDataWrapper pull(RowData lookupRow);
 
     /**
      * Initialize the client.

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/clients/PollingClientFactory.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/clients/PollingClientFactory.java
@@ -19,18 +19,15 @@ package org.apache.flink.connector.http.clients;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.connector.http.table.lookup.HttpLookupConfig;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.ConfigurationException;
 
 import java.io.Serializable;
 
-/**
- * Polling client factory.
- *
- * @param <OUT> polling client
- */
-public interface PollingClientFactory<OUT> extends Serializable {
+/** Polling client factory. */
+public interface PollingClientFactory extends Serializable {
 
-    PollingClient<OUT> createPollClient(
-            HttpLookupConfig options, DeserializationSchema<OUT> schemaDecoder)
+    PollingClient createPollClient(
+            HttpLookupConfig options, DeserializationSchema<RowData> schemaDecoder)
             throws ConfigurationException;
 }

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/config/HttpConnectorConfigConstants.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/config/HttpConnectorConfigConstants.java
@@ -104,6 +104,8 @@ public final class HttpConnectorConfigConstants {
     public static final String SOURCE_CONNECTION_TIMEOUT =
             SOURCE_LOOKUP_PREFIX + "connection.timeout";
 
+    public static final String CONTINUE_ON_ERROR = SOURCE_LOOKUP_PREFIX + "continue-on-error";
+
     public static final String SOURCE_PROXY_HOST = SOURCE_LOOKUP_PREFIX + "proxy.host";
 
     public static final String SOURCE_PROXY_PORT = SOURCE_LOOKUP_PREFIX + "proxy.port";

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpCompletionState.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpCompletionState.java
@@ -15,30 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connector.http.retry;
+package org.apache.flink.connector.http.table.lookup;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-/** Retry strategy type enum. */
-@Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public enum RetryStrategyType {
-    FIXED_DELAY("fixed-delay"),
-    EXPONENTIAL_DELAY("exponential-delay");
-
-    private final String code;
-
-    public static RetryStrategyType fromCode(String code) {
-        if (code == null) {
-            throw new NullPointerException("Code is null");
-        }
-        for (var strategy : RetryStrategyType.values()) {
-            if (strategy.getCode().equalsIgnoreCase(code)) {
-                return strategy;
-            }
-        }
-        throw new IllegalArgumentException("No enum constant for " + code);
-    }
+/** These are the possible ways that the http coll can complete. */
+public enum HttpCompletionState {
+    HTTP_ERROR_STATUS,
+    EXCEPTION,
+    SUCCESS
 }

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpLookupConnectorOptions.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpLookupConnectorOptions.java
@@ -23,6 +23,7 @@ import org.apache.flink.connector.http.retry.RetryStrategyType;
 
 import java.time.Duration;
 
+import static org.apache.flink.connector.http.config.HttpConnectorConfigConstants.CONTINUE_ON_ERROR;
 import static org.apache.flink.connector.http.config.HttpConnectorConfigConstants.LOOKUP_SOURCE_HEADER_USE_RAW;
 import static org.apache.flink.connector.http.config.HttpConnectorConfigConstants.OIDC_AUTH_TOKEN_ENDPOINT_URL;
 import static org.apache.flink.connector.http.config.HttpConnectorConfigConstants.OIDC_AUTH_TOKEN_EXPIRY_REDUCTION;
@@ -114,6 +115,12 @@ public class HttpLookupConnectorOptions {
                     .durationType()
                     .noDefaultValue()
                     .withDescription("Http client connection timeout.");
+
+    public static final ConfigOption<Boolean> SOURCE_LOOKUP_CONTINUE_ON_ERROR =
+            ConfigOptions.key(CONTINUE_ON_ERROR)
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Continue job on error.");
 
     public static final ConfigOption<String> SOURCE_LOOKUP_PROXY_HOST =
             ConfigOptions.key(SOURCE_PROXY_HOST)

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpLookupConnectorOptions.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpLookupConnectorOptions.java
@@ -120,7 +120,9 @@ public class HttpLookupConnectorOptions {
             ConfigOptions.key(CONTINUE_ON_ERROR)
                     .booleanType()
                     .defaultValue(false)
-                    .withDescription("Continue job on error.");
+                    .withDescription(
+                            "Continue job on error. "
+                                    + "This includes unsuccessful HTTP status codes and client side Exceptions, such as Connection Refused.");
 
     public static final ConfigOption<String> SOURCE_LOOKUP_PROXY_HOST =
             ConfigOptions.key(SOURCE_PROXY_HOST)

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpLookupTableSource.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpLookupTableSource.java
@@ -34,12 +34,17 @@ import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.connector.source.lookup.AsyncLookupFunctionProvider;
 import org.apache.flink.table.connector.source.lookup.LookupFunctionProvider;
 import org.apache.flink.table.connector.source.lookup.PartialCachingAsyncLookupProvider;
 import org.apache.flink.table.connector.source.lookup.PartialCachingLookupProvider;
 import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.functions.AsyncLookupFunction;
@@ -54,7 +59,13 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOptions.LOOKUP_QUERY_CREATOR_IDENTIFIER;
 import static org.apache.flink.connector.http.table.lookup.HttpLookupTableSourceFactory.row;
@@ -62,7 +73,10 @@ import static org.apache.flink.connector.http.table.lookup.HttpLookupTableSource
 /** http lookyp table source. */
 @Slf4j
 public class HttpLookupTableSource
-        implements LookupTableSource, SupportsProjectionPushDown, SupportsLimitPushDown {
+        implements LookupTableSource,
+                SupportsReadingMetadata,
+                SupportsProjectionPushDown,
+                SupportsLimitPushDown {
 
     private DataType physicalRowDataType;
 
@@ -72,6 +86,16 @@ public class HttpLookupTableSource
 
     private final DecodingFormat<DeserializationSchema<RowData>> decodingFormat;
     @Nullable private final LookupCache cache;
+
+    // --------------------------------------------------------------------------------------------
+    // Mutable attributes
+    // --------------------------------------------------------------------------------------------
+
+    /** Data type that describes the final output of the source. */
+    protected DataType producedDataType;
+
+    /** Metadata that is appended at the end of a physical source row. */
+    protected List<String> metadataKeys;
 
     public HttpLookupTableSource(
             DataType physicalRowDataType,
@@ -116,7 +140,7 @@ public class HttpLookupTableSource
                 lookupQueryCreatorFactory.createLookupQueryCreator(
                         readableConfig, lookupRow, dynamicTableFactoryContext);
 
-        PollingClientFactory<RowData> pollingClientFactory =
+        PollingClientFactory pollingClientFactory =
                 createPollingClientFactory(lookupQueryCreator, lookupConfig);
 
         return getLookupRuntimeProvider(lookupRow, responseSchemaDecoder, pollingClientFactory);
@@ -125,11 +149,30 @@ public class HttpLookupTableSource
     protected LookupRuntimeProvider getLookupRuntimeProvider(
             LookupRow lookupRow,
             DeserializationSchema<RowData> responseSchemaDecoder,
-            PollingClientFactory<RowData> pollingClientFactory) {
-
+            PollingClientFactory pollingClientFactory) {
+        MetadataConverter[] metadataConverters = {};
+        if (this.metadataKeys != null) {
+            metadataConverters =
+                    this.metadataKeys.stream()
+                            .map(
+                                    k ->
+                                            Stream.of(
+                                                            HttpLookupTableSource.ReadableMetadata
+                                                                    .values())
+                                                    .filter(rm -> rm.key.equals(k))
+                                                    .findFirst()
+                                                    .orElseThrow(IllegalStateException::new))
+                            .map(m -> m.converter)
+                            .toArray(MetadataConverter[]::new);
+        }
         HttpTableLookupFunction dataLookupFunction =
                 new HttpTableLookupFunction(
-                        pollingClientFactory, responseSchemaDecoder, lookupRow, lookupConfig);
+                        pollingClientFactory,
+                        responseSchemaDecoder,
+                        lookupRow,
+                        lookupConfig,
+                        metadataConverters,
+                        this.producedDataType);
         if (lookupConfig.isUseAsync()) {
             AsyncLookupFunction asyncLookupFunction =
                     new AsyncHttpTableLookupFunction(dataLookupFunction);
@@ -174,7 +217,7 @@ public class HttpLookupTableSource
         return true;
     }
 
-    private PollingClientFactory<RowData> createPollingClientFactory(
+    private PollingClientFactory createPollingClientFactory(
             LookupQueryCreator lookupQueryCreator, HttpLookupConfig lookupConfig) {
 
         HeaderPreprocessor headerPreprocessor =
@@ -253,6 +296,128 @@ public class HttpLookupTableSource
         } else {
             return new RowDataSingleValueLookupSchemaEntry(
                     name, RowData.createFieldGetter(type1, parentIndex));
+        }
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        final Map<String, DataType> metadataMap = new LinkedHashMap<>();
+
+        decodingFormat.listReadableMetadata().forEach((key, value) -> metadataMap.put(key, value));
+
+        // according to convention, the order of the final row must be
+        // PHYSICAL + FORMAT METADATA + CONNECTOR METADATA
+        // where the format metadata has highest precedence
+        // add connector metadata
+        Stream.of(ReadableMetadata.values())
+                .forEachOrdered(m -> metadataMap.putIfAbsent(m.key, m.dataType));
+        return metadataMap;
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
+        // separate connector and format metadata
+        final List<String> connectorMetadataKeys = new ArrayList<>(metadataKeys);
+        final Map<String, DataType> formatMetadata = decodingFormat.listReadableMetadata();
+        // store non connector keys and remove them from the connectorMetadataKeys.
+        List<String> formatMetadataKeys = new ArrayList<>();
+        Set<String> metadataKeysSet = metadataKeys.stream().collect(Collectors.toSet());
+        for (ReadableMetadata rm : ReadableMetadata.values()) {
+            String metadataKeyToCheck = rm.name();
+            if (!metadataKeysSet.contains(metadataKeyToCheck)) {
+                formatMetadataKeys.add(metadataKeyToCheck);
+                connectorMetadataKeys.remove(metadataKeyToCheck);
+            }
+        }
+        // push down format metadata keys
+        if (formatMetadata.size() > 0) {
+            final List<String> requestedFormatMetadataKeys =
+                    formatMetadataKeys.stream().collect(Collectors.toList());
+            decodingFormat.applyReadableMetadata(requestedFormatMetadataKeys);
+        }
+        this.metadataKeys = connectorMetadataKeys;
+        this.producedDataType = producedDataType;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Metadata handling
+    // --------------------------------------------------------------------------------------------
+    enum ReadableMetadata {
+        ERROR_STRING(
+                "error-string",
+                DataTypes.STRING(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    public Object read(HttpRowDataWrapper httpRowDataWrapper) {
+                        if (httpRowDataWrapper == null) {
+                            return null;
+                        }
+                        return StringData.fromString(httpRowDataWrapper.getErrorMessage());
+                    }
+                }),
+        HTTP_STATUS_CODE(
+                "http-status-code",
+                DataTypes.INT(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    public Object read(HttpRowDataWrapper httpRowDataWrapper) {
+                        return (httpRowDataWrapper != null)
+                                ? httpRowDataWrapper.getHttpStatusCode()
+                                : null;
+                    }
+                }),
+        HTTP_HEADERS(
+                "http-headers",
+                DataTypes.MAP(DataTypes.STRING(), DataTypes.ARRAY(DataTypes.STRING())),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    public Object read(HttpRowDataWrapper httpRowDataWrapper) {
+                        if (httpRowDataWrapper == null) {
+                            return null;
+                        }
+                        Map<String, List<String>> httpHeadersMap =
+                                httpRowDataWrapper.getHttpHeadersMap();
+                        if (httpHeadersMap == null) {
+                            return null;
+                        }
+                        Map<StringData, ArrayData> stringDataMap = new HashMap<>();
+                        for (String key : httpHeadersMap.keySet()) {
+                            List<StringData> strDataList = new ArrayList<>();
+                            httpHeadersMap.get(key).stream()
+                                    .forEach((c) -> strDataList.add(StringData.fromString(c)));
+                            stringDataMap.put(
+                                    StringData.fromString(key),
+                                    new GenericArrayData(strDataList.toArray()));
+                        }
+                        return new GenericMapData(stringDataMap);
+                    }
+                }),
+        HTTP_COMPLETION_STATE(
+                "http-completion-state",
+                DataTypes.STRING(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    public Object read(HttpRowDataWrapper httpRowDataWrapper) {
+                        if (httpRowDataWrapper == null) {
+                            return null;
+                        }
+                        return StringData.fromString(
+                                httpRowDataWrapper.getHttpCompletionState().name());
+                    }
+                });
+        final String key;
+
+        final DataType dataType;
+        final MetadataConverter converter;
+
+        ReadableMetadata(String key, DataType dataType, MetadataConverter converter) {
+            this.key = key;
+            this.dataType = dataType;
+            this.converter = converter;
         }
     }
 }

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpRowDataWrapper.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpRowDataWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.http.table.lookup;
+
+import org.apache.flink.table.data.RowData;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This bean contains the RowData information (the response body as a flink RowData). It also
+ * contains information from the http response, namely the http headers map and the http status code
+ * where available. The extra information is for the metadata columns.
+ */
+@Builder
+@Data
+public class HttpRowDataWrapper {
+    private final Collection<RowData> data;
+    private final String errorMessage;
+    private final Map<String, List<String>> httpHeadersMap;
+    private final Integer httpStatusCode;
+    private final HttpCompletionState httpCompletionState;
+
+    public boolean shouldIgnore() {
+        return (this.data != null
+                && this.data.isEmpty()
+                && this.errorMessage == null
+                && this.httpHeadersMap == null
+                && this.httpStatusCode == null
+                && httpCompletionState == HttpCompletionState.SUCCESS);
+    }
+}

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpTableLookupFunction.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpTableLookupFunction.java
@@ -22,22 +22,29 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.connector.http.clients.PollingClient;
 import org.apache.flink.connector.http.clients.PollingClientFactory;
 import org.apache.flink.connector.http.utils.SerializationSchemaUtils;
+import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.LookupFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.types.RowKind;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /** lookup function. */
 @Slf4j
 public class HttpTableLookupFunction extends LookupFunction {
 
-    private final PollingClientFactory<RowData> pollingClientFactory;
+    private final PollingClientFactory pollingClientFactory;
 
     private final DeserializationSchema<RowData> responseSchemaDecoder;
 
@@ -50,19 +57,24 @@ public class HttpTableLookupFunction extends LookupFunction {
     private final HttpLookupConfig options;
 
     private transient AtomicInteger localHttpCallCounter;
-
-    private transient PollingClient<RowData> client;
+    private final DataType producedDataType;
+    private transient PollingClient client;
+    private final MetadataConverter[] metadataConverters;
 
     public HttpTableLookupFunction(
-            PollingClientFactory<RowData> pollingClientFactory,
+            PollingClientFactory pollingClientFactory,
             DeserializationSchema<RowData> responseSchemaDecoder,
             LookupRow lookupRow,
-            HttpLookupConfig options) {
+            HttpLookupConfig options,
+            MetadataConverter[] metadataConverters,
+            DataType producedDataType) {
 
         this.pollingClientFactory = pollingClientFactory;
         this.responseSchemaDecoder = responseSchemaDecoder;
         this.lookupRow = lookupRow;
         this.options = options;
+        this.metadataConverters = metadataConverters;
+        this.producedDataType = producedDataType;
     }
 
     @Override
@@ -83,6 +95,55 @@ public class HttpTableLookupFunction extends LookupFunction {
     @Override
     public Collection<RowData> lookup(RowData keyRow) {
         localHttpCallCounter.incrementAndGet();
-        return client.pull(keyRow);
+        List<RowData> outputList = new ArrayList<>();
+        final int metadataArity = metadataConverters.length;
+
+        HttpRowDataWrapper httpRowDataWrapper = client.pull(keyRow);
+        Collection<RowData> httpCollector = httpRowDataWrapper.getData();
+
+        int physicalArity = -1;
+
+        GenericRowData producedRow = null;
+        if (httpRowDataWrapper.shouldIgnore()) {
+            return Collections.emptyList();
+        }
+        // grab the actual data if there is any from the response and populate the producedRow with
+        // it
+        if (!httpCollector.isEmpty()) {
+            // TODO original code increments again if empty - removing
+            //  if (httpCollector.isEmpty()) {
+            // localHttpCallCounter.incrementAndGet();
+            // } else {
+
+            GenericRowData physicalRow = (GenericRowData) httpCollector.iterator().next();
+            physicalArity = physicalRow.getArity();
+            producedRow =
+                    new GenericRowData(physicalRow.getRowKind(), physicalArity + metadataArity);
+            // We need to copy in the physical row into the producedRow
+            for (int pos = 0; pos < physicalArity; pos++) {
+                producedRow.setField(pos, physicalRow.getField(pos));
+            }
+        }
+        // if we did not get the physical arity from the http response physical row then get it from
+        // the producedDataType, which is set when we have metadata
+        if (physicalArity == -1 && producedDataType != null) {
+            List<LogicalType> childrenLogicalTypes =
+                    producedDataType.getLogicalType().getChildren();
+            physicalArity = childrenLogicalTypes.size() - metadataArity;
+        }
+        // if there was no data, create an empty producedRow
+        if (producedRow == null) {
+            producedRow = new GenericRowData(RowKind.INSERT, physicalArity + metadataArity);
+        }
+        // add any metadata
+        if (producedDataType != null) {
+            for (int metadataPos = 0; metadataPos < metadataArity; metadataPos++) {
+                producedRow.setField(
+                        physicalArity + metadataPos,
+                        metadataConverters[metadataPos].read(httpRowDataWrapper));
+            }
+        }
+        outputList.add(producedRow);
+        return outputList;
     }
 }

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpTableLookupFunction.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpTableLookupFunction.java
@@ -110,11 +110,6 @@ public class HttpTableLookupFunction extends LookupFunction {
         // grab the actual data if there is any from the response and populate the producedRow with
         // it
         if (!httpCollector.isEmpty()) {
-            // TODO original code increments again if empty - removing
-            //  if (httpCollector.isEmpty()) {
-            // localHttpCallCounter.incrementAndGet();
-            // } else {
-
             GenericRowData physicalRow = (GenericRowData) httpCollector.iterator().next();
             physicalArity = physicalRow.getArity();
             producedRow =

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClient.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClient.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.http.HttpPostRequestCallback;
+import org.apache.flink.connector.http.HttpStatusCodeValidationFailedException;
 import org.apache.flink.connector.http.clients.PollingClient;
 import org.apache.flink.connector.http.preprocessor.HeaderPreprocessor;
 import org.apache.flink.connector.http.retry.HttpClientWithRetry;
@@ -56,6 +57,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.connector.http.config.HttpConnectorConfigConstants.RESULT_TYPE;
+import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOptions.SOURCE_LOOKUP_CONTINUE_ON_ERROR;
 import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOptions.SOURCE_LOOKUP_HTTP_IGNORED_RESPONSE_CODES;
 import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOptions.SOURCE_LOOKUP_HTTP_RETRY_CODES;
 import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOptions.SOURCE_LOOKUP_HTTP_SUCCESS_CODES;
@@ -66,7 +68,7 @@ import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOp
  * implementation supports HTTP traffic only.
  */
 @Slf4j
-public class JavaNetHttpPollingClient implements PollingClient<RowData> {
+public class JavaNetHttpPollingClient implements PollingClient {
 
     private static final String RESULT_TYPE_SINGLE_VALUE = "single-value";
     private static final String RESULT_TYPE_ARRAY = "array";
@@ -78,6 +80,7 @@ public class JavaNetHttpPollingClient implements PollingClient<RowData> {
     private final HttpPostRequestCallback<HttpLookupSourceRequestEntry> httpPostRequestCallback;
     private final HttpLookupConfig options;
     private final Set<Integer> ignoredErrorCodes;
+    private final boolean continueOnError;
 
     public JavaNetHttpPollingClient(
             HttpClient httpClient,
@@ -100,6 +103,7 @@ public class JavaNetHttpPollingClient implements PollingClient<RowData> {
         var successCodes = new HashSet<Integer>();
         successCodes.addAll(HttpCodesParser.parse(config.get(SOURCE_LOOKUP_HTTP_SUCCESS_CODES)));
         successCodes.addAll(ignoredErrorCodes);
+        this.continueOnError = config.get(SOURCE_LOOKUP_CONTINUE_ON_ERROR);
 
         this.httpClient =
                 HttpClientWithRetry.builder()
@@ -114,9 +118,12 @@ public class JavaNetHttpPollingClient implements PollingClient<RowData> {
     }
 
     @Override
-    public Collection<RowData> pull(RowData lookupRow) {
+    public HttpRowDataWrapper pull(RowData lookupRow) {
         if (lookupRow == null) {
-            return Collections.emptyList();
+            return HttpRowDataWrapper.builder()
+                    .data(Collections.emptyList())
+                    .httpCompletionState(HttpCompletionState.SUCCESS)
+                    .build();
         }
         try {
             log.debug("Collection<RowData> pull with Rowdata={}.", lookupRow);
@@ -126,16 +133,49 @@ public class JavaNetHttpPollingClient implements PollingClient<RowData> {
         }
     }
 
-    private Collection<RowData> queryAndProcess(RowData lookupData) throws Exception {
+    private HttpRowDataWrapper queryAndProcess(RowData lookupData) throws Exception {
         var request = requestFactory.buildLookupRequest(lookupData);
 
         var oidcProcessor =
                 HttpHeaderUtils.createOIDCHeaderPreprocessor(options.getReadableConfig());
-        var response =
-                httpClient.send(
-                        () -> updateHttpRequestIfRequired(request, oidcProcessor),
-                        BodyHandlers.ofString());
-        return processHttpResponse(response, request);
+        HttpResponse<String> response = null;
+        HttpRowDataWrapper httpRowDataWrapper = null;
+        try {
+            response =
+                    httpClient.send(
+                            () -> updateHttpRequestIfRequired(request, oidcProcessor),
+                            BodyHandlers.ofString());
+        } catch (HttpStatusCodeValidationFailedException e) {
+            // Case 1 http non successful response
+            if (!this.continueOnError) {
+                throw e;
+            }
+            // use the response in the Exception
+            response = (HttpResponse<String>) e.getResponse();
+            httpRowDataWrapper = processHttpResponse(response, request, true);
+        } catch (Exception e) {
+            // Case 2 Exception occurred
+            if (!this.continueOnError) {
+                throw e;
+            }
+            String errMessage = e.getMessage();
+            // some exceptions do not have messages including the java.net.ConnectException we can
+            // get here if the connection is bad.
+            if (errMessage == null) {
+                errMessage = e.toString();
+            }
+            return HttpRowDataWrapper.builder()
+                    .data(Collections.emptyList())
+                    .errorMessage(errMessage)
+                    .httpCompletionState(HttpCompletionState.EXCEPTION)
+                    .build();
+        }
+        if (httpRowDataWrapper == null) {
+            // Case 3 Successful path.
+            httpRowDataWrapper = processHttpResponse(response, request, false);
+        }
+
+        return httpRowDataWrapper;
     }
 
     /**
@@ -186,8 +226,17 @@ public class JavaNetHttpPollingClient implements PollingClient<RowData> {
         return httpRequest;
     }
 
-    private Collection<RowData> processHttpResponse(
-            HttpResponse<String> response, HttpLookupSourceRequestEntry request)
+    /**
+     * Process the http response.
+     *
+     * @param response http response
+     * @param request http request
+     * @param isError whether the http response is an error (i.e. not successful after the retry
+     *     processing and accounting for the config)
+     * @return HttpRowDataWrapper http row information and http error information
+     */
+    private HttpRowDataWrapper processHttpResponse(
+            HttpResponse<String> response, HttpLookupSourceRequestEntry request, boolean isError)
             throws IOException {
 
         this.httpPostRequestCallback.call(response, request, "endpoint", Collections.emptyMap());
@@ -199,10 +248,43 @@ public class JavaNetHttpPollingClient implements PollingClient<RowData> {
                 response.statusCode(),
                 responseBody);
 
-        if (StringUtils.isNullOrWhitespaceOnly(responseBody) || ignoreResponse(response)) {
-            return Collections.emptyList();
+        if (!isError
+                && (StringUtils.isNullOrWhitespaceOnly(responseBody) || ignoreResponse(response))) {
+            return HttpRowDataWrapper.builder()
+                    .data(Collections.emptyList())
+                    .httpCompletionState(HttpCompletionState.SUCCESS)
+                    .build();
+        } else {
+            if (isError) {
+                return HttpRowDataWrapper.builder()
+                        .data(Collections.emptyList())
+                        .errorMessage(responseBody)
+                        .httpHeadersMap(response.headers().map())
+                        .httpStatusCode(response.statusCode())
+                        .httpCompletionState(HttpCompletionState.HTTP_ERROR_STATUS)
+                        .build();
+            } else {
+                Collection<RowData> rowData = Collections.emptyList();
+                HttpCompletionState httpCompletionState = HttpCompletionState.SUCCESS;
+                String errMessage = null;
+                try {
+                    rowData = deserialize(responseBody);
+                } catch (IOException e) {
+                    if (!this.continueOnError) {
+                        throw e;
+                    }
+                    httpCompletionState = HttpCompletionState.EXCEPTION;
+                    errMessage = e.getMessage();
+                }
+                return HttpRowDataWrapper.builder()
+                        .data(rowData)
+                        .errorMessage(errMessage)
+                        .httpHeadersMap(response.headers().map())
+                        .httpStatusCode(response.statusCode())
+                        .httpCompletionState(httpCompletionState)
+                        .build();
+            }
         }
-        return deserialize(responseBody);
     }
 
     @VisibleForTesting

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientFactory.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientFactory.java
@@ -26,7 +26,7 @@ import org.apache.flink.util.ConfigurationException;
 import java.net.http.HttpClient;
 
 /** JavaNetHttpPollingClientFactory. */
-public class JavaNetHttpPollingClientFactory implements PollingClientFactory<RowData> {
+public class JavaNetHttpPollingClientFactory implements PollingClientFactory {
 
     private final HttpRequestFactory requestFactory;
 

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/MetadataConverter.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/MetadataConverter.java
@@ -15,30 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connector.http.retry;
+package org.apache.flink.connector.http.table.lookup;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import java.io.Serializable;
 
-/** Retry strategy type enum. */
-@Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public enum RetryStrategyType {
-    FIXED_DELAY("fixed-delay"),
-    EXPONENTIAL_DELAY("exponential-delay");
-
-    private final String code;
-
-    public static RetryStrategyType fromCode(String code) {
-        if (code == null) {
-            throw new NullPointerException("Code is null");
-        }
-        for (var strategy : RetryStrategyType.values()) {
-            if (strategy.getCode().equalsIgnoreCase(code)) {
-                return strategy;
-            }
-        }
-        throw new IllegalArgumentException("No enum constant for " + code);
-    }
+/**
+ * The metadata converters have a read method that is passed a HttpRowDataWrapper. The
+ * implementations pick out the appropriate value of the metadata from this object.
+ */
+interface MetadataConverter extends Serializable {
+    /**
+     * @param httpRowDataWrapper an object that contains all metadata content
+     * @return the metadata value for this MetadataConverter.
+     */
+    Object read(HttpRowDataWrapper httpRowDataWrapper);
 }

--- a/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/HttpRowDataWrapperTest.java
+++ b/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/HttpRowDataWrapperTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.http.table.lookup;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for HttpRowDataWrapper. */
+public class HttpRowDataWrapperTest {
+
+    @Test
+    void testshouldIgnore() {
+        HttpRowDataWrapper httpRowDataWrapper =
+                HttpRowDataWrapper.builder()
+                        .data(Collections.emptyList())
+                        .httpCompletionState(HttpCompletionState.SUCCESS)
+                        .build();
+        assertThat(httpRowDataWrapper.shouldIgnore()).isTrue();
+        httpRowDataWrapper =
+                HttpRowDataWrapper.builder()
+                        .errorMessage("aa")
+                        .httpCompletionState(HttpCompletionState.SUCCESS)
+                        .build();
+        assertThat(httpRowDataWrapper.shouldIgnore()).isFalse();
+        httpRowDataWrapper =
+                HttpRowDataWrapper.builder()
+                        .data(Collections.emptyList())
+                        .errorMessage("aa")
+                        .httpCompletionState(HttpCompletionState.SUCCESS)
+                        .build();
+        assertThat(httpRowDataWrapper.shouldIgnore()).isFalse();
+        httpRowDataWrapper =
+                HttpRowDataWrapper.builder()
+                        .data(Collections.emptyList())
+                        .httpHeadersMap(new HashMap<>())
+                        .httpCompletionState(HttpCompletionState.SUCCESS)
+                        .build();
+        assertThat(httpRowDataWrapper.shouldIgnore()).isFalse();
+        httpRowDataWrapper =
+                HttpRowDataWrapper.builder()
+                        .data(Collections.emptyList())
+                        .httpStatusCode(123)
+                        .httpCompletionState(HttpCompletionState.SUCCESS)
+                        .build();
+        assertThat(httpRowDataWrapper.shouldIgnore()).isFalse();
+        httpRowDataWrapper =
+                HttpRowDataWrapper.builder()
+                        .data(Collections.emptyList())
+                        .httpCompletionState(HttpCompletionState.EXCEPTION)
+                        .build();
+        assertThat(httpRowDataWrapper.shouldIgnore()).isFalse();
+    }
+}

--- a/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientConnectionTest.java
+++ b/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientConnectionTest.java
@@ -160,7 +160,7 @@ class JavaNetHttpPollingClientConnectionTest {
         JavaNetHttpPollingClient pollingClient = setUpPollingClient();
 
         // WHEN
-        Collection<RowData> results = pollingClient.pull(lookupRowData);
+        Collection<RowData> results = pollingClient.pull(lookupRowData).getData();
 
         // THEN
         wireMockServer.verify(RequestPatternBuilder.forCustomMatcher(stubMapping.getRequest()));
@@ -188,7 +188,7 @@ class JavaNetHttpPollingClientConnectionTest {
                 setUpPollingClient(setUpBodyRequestFactory(methodName));
 
         // WHEN
-        Collection<RowData> results = pollingClient.pull(lookupRowData);
+        Collection<RowData> results = pollingClient.pull(lookupRowData).getData();
 
         // THEN
         wireMockServer.verify(RequestPatternBuilder.forCustomMatcher(stubMapping.getRequest()));
@@ -231,7 +231,7 @@ class JavaNetHttpPollingClientConnectionTest {
         JavaNetHttpPollingClient pollingClient = setUpPollingClient();
 
         // WHEN
-        Collection<RowData> results = pollingClient.pull(lookupRowData);
+        Collection<RowData> results = pollingClient.pull(lookupRowData).getData();
 
         // THEN
         wireMockServer.verify(RequestPatternBuilder.forCustomMatcher(stubMapping.getRequest()));
@@ -265,7 +265,7 @@ class JavaNetHttpPollingClientConnectionTest {
         JavaNetHttpPollingClient pollingClient = setUpPollingClient();
 
         // WHEN
-        Collection<RowData> results = pollingClient.pull(lookupRowData);
+        Collection<RowData> results = pollingClient.pull(lookupRowData).getData();
 
         // THEN
         wireMockServer.verify(RequestPatternBuilder.forCustomMatcher(stubMapping.getRequest()));
@@ -298,7 +298,7 @@ class JavaNetHttpPollingClientConnectionTest {
         JavaNetHttpPollingClient pollingClient = setUpPollingClient();
 
         // WHEN
-        Collection<RowData> results = pollingClient.pull(lookupRowData);
+        Collection<RowData> results = pollingClient.pull(lookupRowData).getData();
 
         // THEN
         assertThat(results.isEmpty()).isEqualTo(isExpectedResponseEmpty);
@@ -322,7 +322,7 @@ class JavaNetHttpPollingClientConnectionTest {
         JavaNetHttpPollingClient pollingClient = setUpPollingClient();
 
         // WHEN
-        Collection<RowData> results = pollingClient.pull(null);
+        Collection<RowData> results = pollingClient.pull(null).getData();
 
         // THEN
         assertThat(results.isEmpty()).isTrue();
@@ -352,7 +352,7 @@ class JavaNetHttpPollingClientConnectionTest {
         JavaNetHttpPollingClient pollingClient = setUpPollingClient();
 
         // WHEN
-        Collection<RowData> results = pollingClient.pull(lookupRowData);
+        Collection<RowData> results = pollingClient.pull(lookupRowData).getData();
 
         // THEN
         wireMockServer.verify(RequestPatternBuilder.forCustomMatcher(stubMapping.getRequest()));

--- a/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientHttpsConnectionTest.java
+++ b/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientHttpsConnectionTest.java
@@ -267,7 +267,7 @@ public class JavaNetHttpPollingClientHttpsConnectionTest extends HttpsConnection
 
     private void testPollingClientConnection() throws ConfigurationException {
         JavaNetHttpPollingClient pollingClient = setUpPollingClient(properties);
-        Collection<RowData> result = pollingClient.pull(lookupRowData);
+        Collection<RowData> result = pollingClient.pull(lookupRowData).getData();
 
         assertResult(result);
     }


### PR DESCRIPTION
Port of Getindata PR HTTP-154 https://github.com/getindata/flink-http-connector/commit/dad8f83ac3777702545f8fb16101ed0122b18b28 introducing the capability of continuing on errors in the http connector and metadata columns. 