### PR TITLE
[FLINK-38816] use Flink 2 compatible deserialise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .gitignore.swp
 .project
 .settings
+.metals
 .DS_Store
 /.java-version
 .eslintcache

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClient.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClient.java
@@ -18,6 +18,7 @@
 package org.apache.flink.connector.http.table.lookup;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.functions.util.ListCollector;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.http.HttpLogger;
@@ -32,7 +33,6 @@ import org.apache.flink.connector.http.status.HttpResponseChecker;
 import org.apache.flink.connector.http.utils.HttpHeaderUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.FunctionContext;
-import org.apache.flink.util.Collector;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.StringUtils;
 
@@ -327,36 +327,10 @@ public class JavaNetHttpPollingClient implements PollingClient {
         }
     }
 
-    @VisibleForTesting
-    List<RowData> deserializeSingleValue(byte[] rawBytes) throws IOException {
+    private List<RowData> deserializeSingleValue(byte[] rawBytes) throws IOException {
         List<RowData> result = new ArrayList<>();
-        responseBodyDecoder.deserialize(rawBytes, createRowDataCollector(result));
+        responseBodyDecoder.deserialize(rawBytes, new ListCollector(result));
         return result;
-    }
-
-    @VisibleForTesting
-    Collector<RowData> createRowDataCollector(List<RowData> result) {
-        return new RowDataCollector(result);
-    }
-
-    /** A simple collector implementation that adds RowData records to a list. */
-    @VisibleForTesting
-    static class RowDataCollector implements Collector<RowData> {
-        private final List<RowData> result;
-
-        RowDataCollector(List<RowData> result) {
-            this.result = result;
-        }
-
-        @Override
-        public void collect(RowData record) {
-            result.add(record);
-        }
-
-        @Override
-        public void close() {
-            // No-op - nothing to clean up
-        }
     }
 
     @VisibleForTesting

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClient.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClient.java
@@ -32,6 +32,7 @@ import org.apache.flink.connector.http.status.HttpResponseChecker;
 import org.apache.flink.connector.http.utils.HttpHeaderUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.util.Collector;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.StringUtils;
 
@@ -326,22 +327,49 @@ public class JavaNetHttpPollingClient implements PollingClient {
         }
     }
 
-    private List<RowData> deserializeSingleValue(byte[] rawBytes) throws IOException {
-        return Optional.ofNullable(responseBodyDecoder.deserialize(rawBytes))
-                .map(Collections::singletonList)
-                .orElse(Collections.emptyList());
+    @VisibleForTesting
+    List<RowData> deserializeSingleValue(byte[] rawBytes) throws IOException {
+        List<RowData> result = new ArrayList<>();
+        responseBodyDecoder.deserialize(rawBytes, createRowDataCollector(result));
+        return result;
     }
 
-    private List<RowData> deserializeArray(byte[] rawBytes) throws IOException {
+    @VisibleForTesting
+    Collector<RowData> createRowDataCollector(List<RowData> result) {
+        return new RowDataCollector(result);
+    }
+
+    /** A simple collector implementation that adds RowData records to a list. */
+    @VisibleForTesting
+    static class RowDataCollector implements Collector<RowData> {
+        private final List<RowData> result;
+
+        RowDataCollector(List<RowData> result) {
+            this.result = result;
+        }
+
+        @Override
+        public void collect(RowData record) {
+            result.add(record);
+        }
+
+        @Override
+        public void close() {
+            // No-op - nothing to clean up
+        }
+    }
+
+    @VisibleForTesting
+    List<RowData> deserializeArray(byte[] rawBytes) throws IOException {
         List<JsonNode> rawObjects = objectMapper.readValue(rawBytes, new TypeReference<>() {});
         List<RowData> result = new ArrayList<>();
         for (JsonNode rawObject : rawObjects) {
             if (!(rawObject instanceof NullNode)) {
-                RowData deserialized =
-                        responseBodyDecoder.deserialize(rawObject.toString().getBytes());
-                // deserialize() returns null if deserialization fails
-                if (deserialized != null) {
-                    result.add(deserialized);
+                List<RowData> deserialized =
+                        deserializeSingleValue(rawObject.toString().getBytes());
+                // deserialize() may return empty list if deserialization fails
+                if (deserialized != null && !deserialized.isEmpty()) {
+                    result.addAll(deserialized);
                 }
             }
         }

--- a/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientTest.java
+++ b/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.http.table.lookup;
 
+import org.apache.flink.api.common.functions.util.ListCollector;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
@@ -252,7 +253,7 @@ public class JavaNetHttpPollingClientTest {
                                 headerPreprocessor,
                                 options));
 
-        Collector<RowData> collector = client.createRowDataCollector(result);
+        Collector<RowData> collector = new ListCollector(result);
 
         RowData row1 = GenericRowData.of(StringData.fromString("test1"));
         RowData row2 = GenericRowData.of(StringData.fromString("test2"));
@@ -281,7 +282,7 @@ public class JavaNetHttpPollingClientTest {
                                 headerPreprocessor,
                                 options));
 
-        Collector<RowData> collector = client.createRowDataCollector(result);
+        Collector<RowData> collector = new ListCollector(result);
         collector.collect(GenericRowData.of(StringData.fromString("test")));
 
         // WHEN - close should not throw any exception
@@ -305,7 +306,7 @@ public class JavaNetHttpPollingClientTest {
                                 headerPreprocessor,
                                 options));
 
-        Collector<RowData> collector = client.createRowDataCollector(result);
+        Collector<RowData> collector = new ListCollector(result);
 
         // WHEN - close without collecting anything
         collector.close();

--- a/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientTest.java
+++ b/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Collector;
 import org.apache.flink.util.ConfigurationException;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -41,9 +42,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -233,5 +236,254 @@ public class JavaNetHttpPollingClientTest {
                 "Cache-Control",
                 "no-cache, no-store, max-age=0, must-revalidate");
         assertPropertyArray(headersAndValues, "Access-Control-Allow-Origin", "*");
+    }
+
+    @Test
+    public void shouldCollectRowDataInCollector() throws ConfigurationException {
+        // GIVEN
+        List<RowData> result = new ArrayList<>();
+        JavaNetHttpPollingClient client =
+                new JavaNetHttpPollingClient(
+                        httpClient,
+                        decoder,
+                        options,
+                        new GetRequestFactory(
+                                new GenericGetQueryCreator(lookupRow),
+                                headerPreprocessor,
+                                options));
+
+        Collector<RowData> collector = client.createRowDataCollector(result);
+
+        RowData row1 = GenericRowData.of(StringData.fromString("test1"));
+        RowData row2 = GenericRowData.of(StringData.fromString("test2"));
+
+        // WHEN
+        collector.collect(row1);
+        collector.collect(row2);
+
+        // THEN
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0)).isEqualTo(row1);
+        assertThat(result.get(1)).isEqualTo(row2);
+    }
+
+    @Test
+    public void shouldCallCloseOnRowDataCollectorWithoutException() throws ConfigurationException {
+        // GIVEN
+        List<RowData> result = new ArrayList<>();
+        JavaNetHttpPollingClient client =
+                new JavaNetHttpPollingClient(
+                        httpClient,
+                        decoder,
+                        options,
+                        new GetRequestFactory(
+                                new GenericGetQueryCreator(lookupRow),
+                                headerPreprocessor,
+                                options));
+
+        Collector<RowData> collector = client.createRowDataCollector(result);
+        collector.collect(GenericRowData.of(StringData.fromString("test")));
+
+        // WHEN - close should not throw any exception
+        collector.close();
+
+        // THEN
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void shouldHandleEmptyCollectionInRowDataCollector() throws ConfigurationException {
+        // GIVEN
+        List<RowData> result = new ArrayList<>();
+        JavaNetHttpPollingClient client =
+                new JavaNetHttpPollingClient(
+                        httpClient,
+                        decoder,
+                        options,
+                        new GetRequestFactory(
+                                new GenericGetQueryCreator(lookupRow),
+                                headerPreprocessor,
+                                options));
+
+        Collector<RowData> collector = client.createRowDataCollector(result);
+
+        // WHEN - close without collecting anything
+        collector.close();
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void shouldDeserializeArrayWithValidObjects() throws Exception {
+        // GIVEN
+        DeserializationSchema<RowData> mockDecoder =
+                new DeserializationSchema<RowData>() {
+                    @Override
+                    public RowData deserialize(byte[] message) throws IOException {
+                        return null;
+                    }
+
+                    @Override
+                    public void deserialize(byte[] message, Collector<RowData> out)
+                            throws IOException {
+                        String msg = new String(message);
+                        if (msg.contains("value1")) {
+                            out.collect(GenericRowData.of(StringData.fromString("row1")));
+                        } else if (msg.contains("value2")) {
+                            out.collect(GenericRowData.of(StringData.fromString("row2")));
+                        }
+                        out.close();
+                    }
+
+                    @Override
+                    public boolean isEndOfStream(RowData nextElement) {
+                        return false;
+                    }
+
+                    @Override
+                    public org.apache.flink.api.common.typeinfo.TypeInformation<RowData>
+                            getProducedType() {
+                        return null;
+                    }
+                };
+
+        Properties properties = new Properties();
+        properties.setProperty(HttpConnectorConfigConstants.RESULT_TYPE, "array");
+
+        HttpLookupConfig lookupConfig =
+                HttpLookupConfig.builder().url(BASE_URL).properties(properties).build();
+
+        JavaNetHttpPollingClient client =
+                new JavaNetHttpPollingClient(
+                        httpClient,
+                        mockDecoder,
+                        lookupConfig,
+                        new GetRequestFactory(
+                                new GenericGetQueryCreator(lookupRow),
+                                headerPreprocessor,
+                                lookupConfig));
+
+        // WHEN
+        String jsonArray = "[{\"key\":\"value1\"},{\"key\":\"value2\"}]";
+        List<RowData> result = client.deserializeArray(jsonArray.getBytes());
+
+        // THEN
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    public void shouldHandleNullNodesInArray() throws Exception {
+        // GIVEN
+        DeserializationSchema<RowData> mockDecoder =
+                new DeserializationSchema<RowData>() {
+                    @Override
+                    public RowData deserialize(byte[] message) throws IOException {
+                        return null;
+                    }
+
+                    @Override
+                    public void deserialize(byte[] message, Collector<RowData> out)
+                            throws IOException {
+                        out.collect(GenericRowData.of(StringData.fromString("valid")));
+                        out.close();
+                    }
+
+                    @Override
+                    public boolean isEndOfStream(RowData nextElement) {
+                        return false;
+                    }
+
+                    @Override
+                    public org.apache.flink.api.common.typeinfo.TypeInformation<RowData>
+                            getProducedType() {
+                        return null;
+                    }
+                };
+
+        Properties properties = new Properties();
+        properties.setProperty(HttpConnectorConfigConstants.RESULT_TYPE, "array");
+
+        HttpLookupConfig lookupConfig =
+                HttpLookupConfig.builder().url(BASE_URL).properties(properties).build();
+
+        JavaNetHttpPollingClient client =
+                new JavaNetHttpPollingClient(
+                        httpClient,
+                        mockDecoder,
+                        lookupConfig,
+                        new GetRequestFactory(
+                                new GenericGetQueryCreator(lookupRow),
+                                headerPreprocessor,
+                                lookupConfig));
+
+        // WHEN
+        String jsonArray = "[{\"key\":\"value1\"},null,{\"key\":\"value2\"}]";
+        List<RowData> result = client.deserializeArray(jsonArray.getBytes());
+
+        // THEN - null nodes should be skipped
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    public void shouldHandleEmptyDeserializationInArray() throws Exception {
+        // GIVEN
+        DeserializationSchema<RowData> mockDecoder =
+                new DeserializationSchema<RowData>() {
+                    @Override
+                    public RowData deserialize(byte[] message) throws IOException {
+                        return null;
+                    }
+
+                    @Override
+                    public void deserialize(byte[] message, Collector<RowData> out)
+                            throws IOException {
+                        String msg = new String(message);
+                        // Only collect for specific messages, return empty for others
+                        if (msg.contains("\"status\":\"valid\"")) {
+                            out.collect(GenericRowData.of(StringData.fromString("data")));
+                        }
+                        // Don't collect anything for other messages
+                        out.close();
+                    }
+
+                    @Override
+                    public boolean isEndOfStream(RowData nextElement) {
+                        return false;
+                    }
+
+                    @Override
+                    public org.apache.flink.api.common.typeinfo.TypeInformation<RowData>
+                            getProducedType() {
+                        return null;
+                    }
+                };
+
+        Properties properties = new Properties();
+        properties.setProperty(HttpConnectorConfigConstants.RESULT_TYPE, "array");
+
+        HttpLookupConfig lookupConfig =
+                HttpLookupConfig.builder().url(BASE_URL).properties(properties).build();
+
+        JavaNetHttpPollingClient client =
+                new JavaNetHttpPollingClient(
+                        httpClient,
+                        mockDecoder,
+                        lookupConfig,
+                        new GetRequestFactory(
+                                new GenericGetQueryCreator(lookupRow),
+                                headerPreprocessor,
+                                lookupConfig));
+
+        // WHEN
+        String jsonArray =
+                "[{\"status\":\"invalid\"},{\"status\":\"valid\"},{\"status\":\"invalid\"}]";
+        List<RowData> result = client.deserializeArray(jsonArray.getBytes());
+
+        // THEN - only valid deserialization should be included
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(1);
     }
 }

--- a/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientTest.java
+++ b/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.connector.http.table.lookup;
 
-import org.apache.flink.api.common.functions.util.ListCollector;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
@@ -47,7 +46,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -240,79 +238,52 @@ public class JavaNetHttpPollingClientTest {
     }
 
     @Test
-    public void shouldCollectRowDataInCollector() throws ConfigurationException {
+    public void deserializeSingleValueTest() throws ConfigurationException, IOException {
         // GIVEN
-        List<RowData> result = new ArrayList<>();
+        DeserializationSchema<RowData> mockDecoder =
+                new DeserializationSchema<RowData>() {
+                    @Override
+                    public RowData deserialize(byte[] message) throws IOException {
+                        return null;
+                    }
+
+                    @Override
+                    public void deserialize(byte[] message, Collector<RowData> out)
+                            throws IOException {
+                        String msg = new String(message);
+                        out.collect(GenericRowData.of(StringData.fromString(msg)));
+                        out.close();
+                    }
+
+                    @Override
+                    public boolean isEndOfStream(RowData nextElement) {
+                        return false;
+                    }
+
+                    @Override
+                    public org.apache.flink.api.common.typeinfo.TypeInformation<RowData>
+                            getProducedType() {
+                        return null;
+                    }
+                };
+
         JavaNetHttpPollingClient client =
                 new JavaNetHttpPollingClient(
                         httpClient,
-                        decoder,
+                        mockDecoder,
                         options,
                         new GetRequestFactory(
                                 new GenericGetQueryCreator(lookupRow),
                                 headerPreprocessor,
                                 options));
-
-        Collector<RowData> collector = new ListCollector(result);
-
-        RowData row1 = GenericRowData.of(StringData.fromString("test1"));
-        RowData row2 = GenericRowData.of(StringData.fromString("test2"));
 
         // WHEN
-        collector.collect(row1);
-        collector.collect(row2);
-
-        // THEN
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0)).isEqualTo(row1);
-        assertThat(result.get(1)).isEqualTo(row2);
-    }
-
-    @Test
-    public void shouldCallCloseOnRowDataCollectorWithoutException() throws ConfigurationException {
-        // GIVEN
-        List<RowData> result = new ArrayList<>();
-        JavaNetHttpPollingClient client =
-                new JavaNetHttpPollingClient(
-                        httpClient,
-                        decoder,
-                        options,
-                        new GetRequestFactory(
-                                new GenericGetQueryCreator(lookupRow),
-                                headerPreprocessor,
-                                options));
-
-        Collector<RowData> collector = new ListCollector(result);
-        collector.collect(GenericRowData.of(StringData.fromString("test")));
-
-        // WHEN - close should not throw any exception
-        collector.close();
+        String testString = "Test1";
+        List<RowData> result = client.deserializeSingleValue(testString.getBytes());
 
         // THEN
         assertThat(result).hasSize(1);
-    }
-
-    @Test
-    public void shouldHandleEmptyCollectionInRowDataCollector() throws ConfigurationException {
-        // GIVEN
-        List<RowData> result = new ArrayList<>();
-        JavaNetHttpPollingClient client =
-                new JavaNetHttpPollingClient(
-                        httpClient,
-                        decoder,
-                        options,
-                        new GetRequestFactory(
-                                new GenericGetQueryCreator(lookupRow),
-                                headerPreprocessor,
-                                options));
-
-        Collector<RowData> collector = new ListCollector(result);
-
-        // WHEN - close without collecting anything
-        collector.close();
-
-        // THEN
-        assertThat(result).isEmpty();
+        assertThat(((StringData) result.get(0).getString(0)).toString()).isEqualTo(testString);
     }
 
     @Test


### PR DESCRIPTION
The version of deserialise method that is used by this connector is deprecated at Flink 2, and a Runtime Exception is thrown. This change means that the Flink 2 compatible deserialise method is now used. 

This is a port of the GetInData PR [HTTP 204](https://github.com/getindata/flink-http-connector/pull/204); getindata requires 90% code coverage, the code has been implemented to be testable and meet this requirement then ported as is.     