### PR TITLE
[hotfix] Fix typos in constants, Javadoc and documentation

### DIFF
--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/config/HttpConnectorConfigConstants.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/config/HttpConnectorConfigConstants.java
@@ -122,7 +122,7 @@ public final class HttpConnectorConfigConstants {
     public static final String SINK_HTTP_TIMEOUT_SECONDS =
             FLINK_CONNECTOR_HTTP + "sink.request.timeout";
 
-    public static final String LOOKUP_HTTP_PULING_THREAD_POOL_SIZE =
+    public static final String LOOKUP_HTTP_POLLING_THREAD_POOL_SIZE =
             SOURCE_LOOKUP_PREFIX + "request.thread-pool.size";
 
     public static final String LOOKUP_HTTP_RESPONSE_THREAD_POOL_SIZE =

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/sink/HttpSinkWriter.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/sink/HttpSinkWriter.java
@@ -90,7 +90,7 @@ public class HttpSinkWriter<InputT> extends AsyncSinkWriter<InputT, HttpSinkRequ
         var metrics = context.metricGroup();
         this.numRecordsSendErrorsCounter = metrics.getNumRecordsSendErrorsCounter();
 
-        int sinkWriterThreadPollSize =
+        int sinkWriterThreadPoolSize =
                 Integer.parseInt(
                         properties.getProperty(
                                 HttpConnectorConfigConstants.SINK_HTTP_WRITER_THREAD_POOL_SIZE,
@@ -98,7 +98,7 @@ public class HttpSinkWriter<InputT> extends AsyncSinkWriter<InputT, HttpSinkRequ
 
         this.sinkWriterThreadPool =
                 Executors.newFixedThreadPool(
-                        sinkWriterThreadPollSize,
+                        sinkWriterThreadPoolSize,
                         new ExecutorThreadFactory(
                                 "http-sink-writer-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
     }
@@ -127,9 +127,7 @@ public class HttpSinkWriter<InputT> extends AsyncSinkWriter<InputT, HttpSinkRequ
                         // requestResult.accept(requestEntries);
                     } else if (response.getFailedRequests().size() > 0) {
                         int failedRequestsNumber = response.getFailedRequests().size();
-                        log.error(
-                                "Http Sink failed to write and will retry {} requests",
-                                failedRequestsNumber);
+                        log.error("Http Sink failed to write {} requests", failedRequestsNumber);
                         numRecordsSendErrorsCounter.inc(failedRequestsNumber);
 
                         // TODO: Make `HttpSinkInternal` retry the failed requests. Currently,

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/status/ComposeHttpStatusCodeChecker.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/status/ComposeHttpStatusCodeChecker.java
@@ -49,7 +49,7 @@ public class ComposeHttpStatusCodeChecker implements HttpStatusCodeChecker {
     private final Set<IncludeListHttpStatusCodeChecker> includedCodes;
 
     /**
-     * Set of {@link HttpStatusCodeChecker} that check status code againts value match or {@link
+     * Set of {@link HttpStatusCodeChecker} that check status code against value match or {@link
      * HttpResponseCodeType} match.
      */
     private final Set<HttpStatusCodeChecker> errorCodes;

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/status/HttpResponseChecker.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/status/HttpResponseChecker.java
@@ -64,7 +64,7 @@ public class HttpResponseChecker {
 
     private void validate() throws ConfigurationException {
         if (successCodes.isEmpty()) {
-            throw new ConfigurationException("Success code list can not be empty");
+            throw new ConfigurationException("Success code list cannot be empty");
         }
         var intersection = new HashSet<>(successCodes);
         intersection.retainAll(temporalErrorCodes);
@@ -72,7 +72,7 @@ public class HttpResponseChecker {
             throw new ConfigurationException(
                     "Http codes "
                             + intersection
-                            + " can not be used as both success and retry codes");
+                            + " cannot be used as both success and retry codes");
         }
     }
 }

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/AsyncHttpTableLookupFunction.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/AsyncHttpTableLookupFunction.java
@@ -64,7 +64,7 @@ public class AsyncHttpTableLookupFunction extends AsyncLookupFunction {
                                 .getProperties()
                                 .getProperty(
                                         HttpConnectorConfigConstants
-                                                .LOOKUP_HTTP_PULING_THREAD_POOL_SIZE,
+                                                .LOOKUP_HTTP_POLLING_THREAD_POOL_SIZE,
                                         PULLING_THREAD_POOL_SIZE));
 
         int publishingThreadPoolSize =

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClient.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClient.java
@@ -199,7 +199,7 @@ public class JavaNetHttpPollingClient implements PollingClient {
      * If using OIDC, update the http request using the oidc header pre processor to supply the
      * authentication header, with a short lived bearer token.
      *
-     * @param request http reauest to amend
+     * @param request http request to amend
      * @param oidcHeaderPreProcessor OIDC header pre processor
      * @return http request, which for OIDC will have the bearer token as the authentication header
      */

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/querycreators/PrefixedConfigOption.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/querycreators/PrefixedConfigOption.java
@@ -70,7 +70,7 @@ public class PrefixedConfigOption<T> {
              * configOption as this object is loaded using a different classloader.
              * Without changing Flink to make the constructor, methods and fields public, we need
              * to use reflection to access and create the new prefixed ConfigOption. It is not
-             * great practise to use reflection, but getting round this classloader issue
+             * great practice to use reflection, but getting round this classloader issue
              * necessitates it's use.
              */
             Constructor constructor = other.getClass().getDeclaredConstructors()[0];

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/utils/HttpHeaderUtils.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/utils/HttpHeaderUtils.java
@@ -64,11 +64,11 @@ public final class HttpHeaderUtils {
             String propertyName = headerAndValue.getKey();
             String headerValue = headerAndValue.getValue();
             log.info(
-                    "prepareHeaderMap propertyName=" + propertyName + ",headerValue" + headerValue);
+                    "prepareHeaderMap propertyName={}, headerValue={}", propertyName, headerValue);
             String headerName = ConfigUtils.extractPropertyLastElement(propertyName);
             String preProcessedHeader =
                     headerPreprocessor.preprocessValueForHeader(headerName, headerValue);
-            log.info("prepareHeaderMap preProcessedHeader=" + preProcessedHeader);
+            log.info("prepareHeaderMap preProcessedHeader={}", preProcessedHeader);
             headerMap.put(headerName, preProcessedHeader);
         }
         return headerMap;
@@ -85,7 +85,7 @@ public final class HttpHeaderUtils {
      * )
      * }</pre>
      *
-     * <p>will be converter to an array of:
+     * <p>will be converted to an array of:
      *
      * <pre>{@code
      * String[] headers = {"header1", "val1", "header2", "val2"};

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/utils/HttpHeaderUtils.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/utils/HttpHeaderUtils.java
@@ -63,8 +63,7 @@ public final class HttpHeaderUtils {
         for (Entry<String, String> headerAndValue : propertyHeaderMap.entrySet()) {
             String propertyName = headerAndValue.getKey();
             String headerValue = headerAndValue.getValue();
-            log.info(
-                    "prepareHeaderMap propertyName={}, headerValue={}", propertyName, headerValue);
+            log.info("prepareHeaderMap propertyName={}, headerValue={}", propertyName, headerValue);
             String headerName = ConfigUtils.extractPropertyLastElement(propertyName);
             String preProcessedHeader =
                     headerPreprocessor.preprocessValueForHeader(headerName, headerValue);

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/utils/JavaNetHttpClientFactory.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/utils/JavaNetHttpClientFactory.java
@@ -150,7 +150,7 @@ public class JavaNetHttpClientFactory {
 
         if (StringUtils.isNullOrWhitespaceOnly(keyStorePath)
                 && !selfSignedCert
-                // checking the property in this way so that serverTrustedCerts is not left and null
+                // checking the property in this way so that serverTrustedCerts is not left as null
                 // or empty, which causes the http client to error.
                 && (properties.getProperty(HttpConnectorConfigConstants.SERVER_TRUSTED_CERT)
                         == null)
@@ -194,11 +194,11 @@ public class JavaNetHttpClientFactory {
 
     private static List<TrustManager> wrapWithSelfSignedManagers(TrustManager[] trustManagers) {
         log.warn(
-                "Creating Trust Managers for self-signed certificates - not Recommended. "
+                "Creating Trust Managers for self-signed certificates - not recommended. "
                         + "Use ["
                         + HttpConnectorConfigConstants.SERVER_TRUSTED_CERT
                         + "] "
-                        + "connector property to add certificated as trusted.");
+                        + "connector property to add certificates as trusted.");
 
         List<TrustManager> selfSignedManagers = new ArrayList<>(trustManagers.length);
         for (TrustManager trustManager : trustManagers) {

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/utils/uri/ParserCursor.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/utils/uri/ParserCursor.java
@@ -42,7 +42,7 @@ class ParserCursor {
             throw new IndexOutOfBoundsException("Lower bound cannot be negative");
         }
         if (lowerBound > upperBound) {
-            throw new IndexOutOfBoundsException("Lower bound cannot be greater then upper bound");
+            throw new IndexOutOfBoundsException("Lower bound cannot be greater than upper bound");
         }
         this.lowerBound = lowerBound;
         this.upperBound = upperBound;

--- a/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/AsyncHttpTableLookupFunctionTest.java
+++ b/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/AsyncHttpTableLookupFunctionTest.java
@@ -98,7 +98,7 @@ class AsyncHttpTableLookupFunctionTest {
         assertThat(latch.await(3, TimeUnit.SECONDS))
                 .withFailMessage(
                         "Future complete in AsyncHttpTableLookupFunction was not called"
-                                + " for at lest one event.")
+                                + " for at least one event.")
                 .isEqualTo(true);
 
         assertThat(result.size()).isEqualTo(rowKeys.length);
@@ -138,7 +138,7 @@ class AsyncHttpTableLookupFunctionTest {
         assertThat(latch.await(3, TimeUnit.SECONDS))
                 .withFailMessage(
                         "Future complete in AsyncHttpTableLookupFunction was not called"
-                                + " for at lest one event.")
+                                + " for at least one event.")
                 .isEqualTo(true);
 
         assertThat(wasException).isTrue();
@@ -176,13 +176,13 @@ class AsyncHttpTableLookupFunctionTest {
         assertThat(latch.await(3, TimeUnit.SECONDS))
                 .withFailMessage(
                         "Future complete in AsyncHttpTableLookupFunction was not called"
-                                + " for at lest one event.")
+                                + " for at least one event.")
                 .isEqualTo(true);
 
         assertThat(completeCount.get())
                 .withFailMessage(
                         "Future complete in AsyncHttpTableLookupFunction was not called"
-                                + " for at lest one event.")
+                                + " for at least one event.")
                 .isEqualTo(rowKeys.length);
 
         // -1 since one will have one empty result.


### PR DESCRIPTION
Fix typos in constants, Javadoc, comments, tests and documentation across the HTTP connector codebase.