### PR TITLE
[FLINK-39368][connector-http] Add User-Agent configuration support for HTTP sink and lookup

### DIFF
--- a/docs/content.zh/docs/connectors/table/http.md
+++ b/docs/content.zh/docs/connectors/table/http.md
@@ -51,6 +51,7 @@ The HTTP source connector supports [Lookup Joins](https://nightlies.apache.org/f
       * [For HTTP responses](#for-http-responses)
     * [Default Query Creator Implementation](#default-query-creator-implementation)
     * [Http headers](#http-headers)
+    * [User-Agent](#user-agent)
     * [Timeouts](#timeouts)
     * [Source table HTTP status code](#source-table-http-status-code)
     * [Retries and handling errors (Lookup source)](#retries-and-handling-errors-lookup-source)
@@ -208,6 +209,7 @@ Note the options with the prefix _http_ are the HTTP connector specific options,
 | http.request.query-param-fields-with-key                               | optional | A map of column names to query parameter keys. See the [Query Parameter Mapping](#query-parameter-mapping) section for details and examples.                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | http.request.body-template                                             | optional | Used for the `http-generic-json-url` query creator. A JSON template string for constructing the request body for PUT and POST operations. Use `{{fieldName}}` placeholders to reference top-level columns from the lookup table. Supports creating complex nested JSON structures with both placeholders and literal values. See the [Body Template](#body-template) section for details and examples.                                                                                                                                                                                                     |
 | http.request.url-map                                                   | optional | Used for the `http-generic-json-url` query creator. The map of insert names to column names used as url segments. Parses a string as a map of strings. For example if there are table columns called `customerId` and `orderId`, then specifying value `customerId:cid,orderID:oid` and a url of https://myendpoint/customers/{cid}/orders/{oid} will mean that the url used for the lookup query will dynamically pickup the values for `customerId`, `orderId` and use them in the url e.g. https://myendpoint/customers/cid1/orders/oid1. The expected format of the map is: `key1:value1,key2:value2`. |
+| http.user.agent                                                        | optional | The value of the `User-Agent` HTTP header sent with every lookup request. Defaults to `flink-connector-http`. Setting this option together with `http.source.lookup.header.User-Agent` is not allowed and will fail with a configuration error.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
 ### Query Creators
 
@@ -448,6 +450,32 @@ CREATE TABLE http-lookup (
 Note that when using OIDC, it adds an `Authentication` header with the bearer token; this will override
 an existing `Authorization` header specified in configuration.
 
+### User-Agent
+
+The `User-Agent` header value can be configured via the dedicated `http.user.agent` option. When not
+specified, the connector sends every request with `User-Agent: flink-connector-http`. This makes the
+connector identifiable to the target server out of the box and is useful for server-side logging,
+rate limiting and access auditing.
+
+```roomsql
+CREATE TABLE Customers (
+  id INT,
+  name STRING,
+  email STRING
+) WITH (
+  'connector' = 'http',
+  'url' = 'http://api.example.com/customers',
+  'format' = 'json',
+  'http.user.agent' = 'MyApp/1.0'
+)
+```
+
+The same option is also available for the HTTP sink, see the [Sink Connector Options](#sink-connector-options) table.
+
+Setting `User-Agent` through both `http.user.agent` and `http.source.lookup.header.User-Agent`
+(or `http.sink.header.User-Agent` for the sink) is ambiguous and is rejected at table creation time
+with an `IllegalArgumentException`. Configure it through exactly one of the two options.
+
 ### Timeouts
 Lookup Source is guarded by two timeout timers. First one is specified by Flink's AsyncIO operator that executes `AsyncTableFunction`.
 The default value of this timer is set to 3 minutes and can be changed via `table.exec.async-lookup.timeout` [option](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/config/#table-exec-async-lookup-timeout).
@@ -547,6 +575,7 @@ another format name.
 | http.sink.writer.thread-pool.size         | optional | Sets the size of pool thread for HTTP Sink request processing. Increasing this value would mean that more concurrent requests can be processed in the same time. If not specified, the default value of 1 thread will be used.     |
 | http.sink.writer.request.mode             | optional | Sets the Http Sink request submission mode. Two modes are available: `single` and `batch`. Defaults to `batch` if not specified. |
 | http.sink.request.batch.size              | optional | Applicable only for `http.sink.writer.request.mode = batch`. Sets number of individual events/requests that will be submitted as one HTTP request by HTTP sink. The default value is 500 which is same as HTTP Sink `maxBatchSize` |
+| http.user.agent                           | optional | The value of the `User-Agent` HTTP header sent with every sink request. Defaults to `flink-connector-http`. Setting this option together with `http.sink.header.User-Agent` is not allowed and will fail with a configuration error.                                                                                                |
 
 ### Sink table HTTP status codes
 You can configure a list of HTTP status codes that should be treated as errors for HTTP sink table.

--- a/docs/content/docs/connectors/table/http.md
+++ b/docs/content/docs/connectors/table/http.md
@@ -51,6 +51,7 @@ The HTTP source connector supports [Lookup Joins](https://nightlies.apache.org/f
       * [For HTTP responses](#for-http-responses)
     * [Default Query Creator Implementation](#default-query-creator-implementation)
     * [Http headers](#http-headers)
+    * [User-Agent](#user-agent)
     * [Timeouts](#timeouts)
     * [Source table HTTP status code](#source-table-http-status-code)
     * [Retries and handling errors (Lookup source)](#retries-and-handling-errors-lookup-source)
@@ -208,6 +209,7 @@ Note the options with the prefix _http_ are the HTTP connector specific options,
 | http.request.query-param-fields-with-key                               | optional | A map of column names to query parameter keys. See the [Query Parameter Mapping](#query-parameter-mapping) section for details and examples.                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | http.request.body-template                                             | optional | Used for the `http-generic-json-url` query creator. A JSON template string for constructing the request body for PUT and POST operations. Use `{{fieldName}}` placeholders to reference top-level columns from the lookup table. Supports creating complex nested JSON structures with both placeholders and literal values. See the [Body Template](#body-template) section for details and examples.                                                                                                                                                                                                     |
 | http.request.url-map                                                   | optional | Used for the `http-generic-json-url` query creator. The map of insert names to column names used as url segments. Parses a string as a map of strings. For example if there are table columns called `customerId` and `orderId`, then specifying value `customerId:cid,orderID:oid` and a url of https://myendpoint/customers/{cid}/orders/{oid} will mean that the url used for the lookup query will dynamically pickup the values for `customerId`, `orderId` and use them in the url e.g. https://myendpoint/customers/cid1/orders/oid1. The expected format of the map is: `key1:value1,key2:value2`. |
+| http.user.agent                                                        | optional | The value of the `User-Agent` HTTP header sent with every lookup request. Defaults to `flink-connector-http`. Setting this option together with `http.source.lookup.header.User-Agent` is not allowed and will fail with a configuration error.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
 ### Query Creators
 
@@ -448,6 +450,32 @@ CREATE TABLE http-lookup (
 Note that when using OIDC, it adds an `Authentication` header with the bearer token; this will override
 an existing `Authorization` header specified in configuration.
 
+### User-Agent
+
+The `User-Agent` header value can be configured via the dedicated `http.user.agent` option. When not
+specified, the connector sends every request with `User-Agent: flink-connector-http`. This makes the
+connector identifiable to the target server out of the box and is useful for server-side logging,
+rate limiting and access auditing.
+
+```roomsql
+CREATE TABLE Customers (
+  id INT,
+  name STRING,
+  email STRING
+) WITH (
+  'connector' = 'http',
+  'url' = 'http://api.example.com/customers',
+  'format' = 'json',
+  'http.user.agent' = 'MyApp/1.0'
+)
+```
+
+The same option is also available for the HTTP sink, see the [Sink Connector Options](#sink-connector-options) table.
+
+Setting `User-Agent` through both `http.user.agent` and `http.source.lookup.header.User-Agent`
+(or `http.sink.header.User-Agent` for the sink) is ambiguous and is rejected at table creation time
+with an `IllegalArgumentException`. Configure it through exactly one of the two options.
+
 ### Timeouts
 Lookup Source is guarded by two timeout timers. First one is specified by Flink's AsyncIO operator that executes `AsyncTableFunction`.
 The default value of this timer is set to 3 minutes and can be changed via `table.exec.async-lookup.timeout` [option](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/config/#table-exec-async-lookup-timeout).
@@ -547,6 +575,7 @@ another format name.
 | http.sink.writer.thread-pool.size         | optional | Sets the size of pool thread for HTTP Sink request processing. Increasing this value would mean that more concurrent requests can be processed in the same time. If not specified, the default value of 1 thread will be used.     |
 | http.sink.writer.request.mode             | optional | Sets the Http Sink request submission mode. Two modes are available: `single` and `batch`. Defaults to `batch` if not specified. |
 | http.sink.request.batch.size              | optional | Applicable only for `http.sink.writer.request.mode = batch`. Sets number of individual events/requests that will be submitted as one HTTP request by HTTP sink. The default value is 500 which is same as HTTP Sink `maxBatchSize` |
+| http.user.agent                           | optional | The value of the `User-Agent` HTTP header sent with every sink request. Defaults to `flink-connector-http`. Setting this option together with `http.sink.header.User-Agent` is not allowed and will fail with a configuration error.                                                                                                |
 
 ### Sink table HTTP status codes
 You can configure a list of HTTP status codes that should be treated as errors for HTTP sink table.

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/sink/httpclient/JavaNetSinkHttpClient.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/sink/httpclient/JavaNetSinkHttpClient.java
@@ -28,6 +28,7 @@ import org.apache.flink.connector.http.sink.HttpSinkRequestEntry;
 import org.apache.flink.connector.http.status.ComposeHttpStatusCodeChecker;
 import org.apache.flink.connector.http.status.ComposeHttpStatusCodeChecker.ComposeHttpStatusCodeCheckerConfig;
 import org.apache.flink.connector.http.status.HttpStatusCodeChecker;
+import org.apache.flink.connector.http.table.sink.HttpDynamicSinkConnectorOptions;
 import org.apache.flink.connector.http.utils.HttpHeaderUtils;
 
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +73,23 @@ public class JavaNetSinkHttpClient implements SinkHttpClient {
                         HttpConnectorConfigConstants.SINK_HEADER_PREFIX,
                         properties,
                         headerPreprocessor);
+
+        // Apply the User-Agent header. If the user also set it via
+        // 'http.sink.header.User-Agent', fail fast so that we do not silently drop
+        // one of the two values.
+        String userAgent =
+                properties.getProperty(
+                        HttpDynamicSinkConnectorOptions.USER_AGENT.key(),
+                        HttpDynamicSinkConnectorOptions.USER_AGENT.defaultValue());
+        if (userAgent != null && !userAgent.isEmpty()) {
+            if (this.headerMap.containsKey("User-Agent")) {
+                throw new IllegalArgumentException(
+                        "User-Agent header is set both explicitly via 'http.user.agent' "
+                                + "and via 'http.sink.header.User-Agent'. "
+                                + "Please use only one of them to configure the User-Agent header.");
+            }
+            this.headerMap.put("User-Agent", userAgent);
+        }
 
         // TODO Inject this via constructor when implementing a response processor.
         //  Processor will be injected and it will wrap statusChecker implementation.

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpLookupConnectorOptions.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpLookupConnectorOptions.java
@@ -243,4 +243,15 @@ public class HttpLookupConnectorOptions {
                                     + "Ignored responses togater with `"
                                     + SOURCE_RETRY_SUCCESS_CODES
                                     + "` are considered as successful.");
+
+    public static final ConfigOption<String> SOURCE_LOOKUP_USER_AGENT =
+            ConfigOptions.key("http.user.agent")
+                    .stringType()
+                    .defaultValue("flink-connector-http")
+                    .withDescription(
+                            "The User-Agent header value for HTTP lookup requests. "
+                                    + "Default value is 'flink-connector-http'. "
+                                    + "Setting User-Agent simultaneously via this option and "
+                                    + "'http.source.lookup.header.User-Agent' is not allowed and "
+                                    + "will fail with a configuration error.");
 }

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpLookupTableSourceFactory.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/HttpLookupTableSourceFactory.java
@@ -69,6 +69,7 @@ import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOp
 import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOptions.SOURCE_LOOKUP_RETRY_EXPONENTIAL_DELAY_MULTIPLIER;
 import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOptions.SOURCE_LOOKUP_RETRY_FIXED_DELAY_DELAY;
 import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOptions.SOURCE_LOOKUP_RETRY_STRATEGY;
+import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOptions.SOURCE_LOOKUP_USER_AGENT;
 import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOptions.URL;
 import static org.apache.flink.connector.http.table.lookup.HttpLookupConnectorOptions.URL_ARGS;
 import static org.apache.flink.table.api.DataTypes.FIELD;
@@ -206,7 +207,8 @@ public class HttpLookupTableSourceFactory implements DynamicTableSourceFactory {
                 SOURCE_LOOKUP_PROXY_USERNAME,
                 SOURCE_LOOKUP_PROXY_PASSWORD,
                 SOURCE_LOOKUP_CONNECTION_TIMEOUT,
-                SOURCE_LOOKUP_REQUEST_TIMEOUT);
+                SOURCE_LOOKUP_REQUEST_TIMEOUT,
+                SOURCE_LOOKUP_USER_AGENT);
     }
 
     private HttpLookupConfig getHttpLookupOptions(Context context, ReadableConfig readableConfig) {

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/RequestFactoryBase.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/lookup/RequestFactoryBase.java
@@ -73,6 +73,22 @@ public abstract class RequestFactoryBase implements HttpRequestFactory {
                         options.getProperties(),
                         headerPreprocessor);
 
+        // Apply the User-Agent header. If the user also set it via
+        // 'http.source.lookup.header.User-Agent', fail fast so that we do not silently
+        // drop one of the two values.
+        String userAgent =
+                options.getReadableConfig()
+                        .get(HttpLookupConnectorOptions.SOURCE_LOOKUP_USER_AGENT);
+        if (userAgent != null && !userAgent.isEmpty()) {
+            if (headerMap.containsKey("User-Agent")) {
+                throw new IllegalArgumentException(
+                        "User-Agent header is set both explicitly via 'http.user.agent' "
+                                + "and via 'http.source.lookup.header.User-Agent'. "
+                                + "Please use only one of them to configure the User-Agent header.");
+            }
+            headerMap.put("User-Agent", userAgent);
+        }
+
         this.headersAndValues = HttpHeaderUtils.toHeaderAndValueArray(headerMap);
 
         this.httpRequestTimeOutSeconds =

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/sink/HttpDynamicSinkConnectorOptions.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/sink/HttpDynamicSinkConnectorOptions.java
@@ -58,4 +58,15 @@ public class HttpDynamicSinkConnectorOptions {
             ConfigOptions.key(SINK_REQUEST_CALLBACK_IDENTIFIER)
                     .stringType()
                     .defaultValue(Slf4jHttpPostRequestCallbackFactory.IDENTIFIER);
+
+    public static final ConfigOption<String> USER_AGENT =
+            ConfigOptions.key("http.user.agent")
+                    .stringType()
+                    .defaultValue("flink-connector-http")
+                    .withDescription(
+                            "The User-Agent header value for HTTP sink requests. "
+                                    + "Default value is 'flink-connector-http'. "
+                                    + "Setting User-Agent simultaneously via this option and "
+                                    + "'http.sink.header.User-Agent' is not allowed and will "
+                                    + "fail with a configuration error.");
 }

--- a/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/sink/HttpDynamicTableSinkFactory.java
+++ b/flink-connector-http/src/main/java/org/apache/flink/connector/http/table/sink/HttpDynamicTableSinkFactory.java
@@ -35,6 +35,7 @@ import static org.apache.flink.connector.http.table.sink.HttpDynamicSinkConnecto
 import static org.apache.flink.connector.http.table.sink.HttpDynamicSinkConnectorOptions.REQUEST_CALLBACK_IDENTIFIER;
 import static org.apache.flink.connector.http.table.sink.HttpDynamicSinkConnectorOptions.SINK_REQUEST_TIMEOUT;
 import static org.apache.flink.connector.http.table.sink.HttpDynamicSinkConnectorOptions.URL;
+import static org.apache.flink.connector.http.table.sink.HttpDynamicSinkConnectorOptions.USER_AGENT;
 
 /** Factory for creating {@link HttpDynamicSink}. */
 public class HttpDynamicTableSinkFactory extends AsyncDynamicTableSinkFactory {
@@ -98,6 +99,7 @@ public class HttpDynamicTableSinkFactory extends AsyncDynamicTableSinkFactory {
         options.add(INSERT_METHOD);
         options.add(SINK_REQUEST_TIMEOUT);
         options.add(REQUEST_CALLBACK_IDENTIFIER);
+        options.add(USER_AGENT);
         return options;
     }
 

--- a/flink-connector-http/src/test/java/org/apache/flink/connector/http/sink/httpclient/JavaNetSinkHttpClientTest.java
+++ b/flink-connector-http/src/test/java/org/apache/flink/connector/http/sink/httpclient/JavaNetSinkHttpClientTest.java
@@ -41,9 +41,10 @@ import java.util.stream.Stream;
 
 import static org.apache.flink.connector.http.TestHelper.assertPropertyArray;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
 
 /** Test for {@link JavaNetSinkHttpClient }. */
 @ExtendWith(MockitoExtension.class)
@@ -74,9 +75,9 @@ class JavaNetSinkHttpClientTest {
         postRequestCallback = new Slf4jHttpPostRequestCallback();
         headerPreprocessor = HttpHeaderUtils.createBasicAuthorizationHeaderPreprocessor();
         httpClientStaticMock.when(HttpClient::newBuilder).thenReturn(httpClientBuilder);
-        when(httpClientBuilder.followRedirects(any())).thenReturn(httpClientBuilder);
-        when(httpClientBuilder.sslContext(any())).thenReturn(httpClientBuilder);
-        when(httpClientBuilder.executor(any())).thenReturn(httpClientBuilder);
+        lenient().when(httpClientBuilder.followRedirects(any())).thenReturn(httpClientBuilder);
+        lenient().when(httpClientBuilder.sslContext(any())).thenReturn(httpClientBuilder);
+        lenient().when(httpClientBuilder.executor(any())).thenReturn(httpClientBuilder);
     }
 
     private static Stream<Arguments> provideSubmitterFactory() {
@@ -95,7 +96,11 @@ class JavaNetSinkHttpClientTest {
                         postRequestCallback,
                         this.headerPreprocessor,
                         requestSubmitterFactory);
-        assertThat(client.getHeadersAndValues()).isEmpty();
+        String[] headersAndValues = client.getHeadersAndValues();
+        // By default, User-Agent header is always added with default value
+        assertThat(headersAndValues).hasSize(2);
+        assertThat(headersAndValues[0]).isEqualTo("User-Agent");
+        assertThat(headersAndValues[1]).isEqualTo("flink-connector-http");
     }
 
     @ParameterizedTest
@@ -124,7 +129,8 @@ class JavaNetSinkHttpClientTest {
                         headerPreprocessor,
                         requestSubmitterFactory);
         String[] headersAndValues = client.getHeadersAndValues();
-        assertThat(headersAndValues).hasSize(6);
+        // 3 custom headers + default User-Agent header = 8 total (4 pairs)
+        assertThat(headersAndValues).hasSize(8);
 
         // THEN
         // assert that we have property followed by its value.
@@ -134,5 +140,72 @@ class JavaNetSinkHttpClientTest {
                 "Cache-Control",
                 "no-cache, no-store, max-age=0, must-revalidate");
         assertPropertyArray(headersAndValues, "Access-Control-Allow-Origin", "*");
+        // Default User-Agent header should also be present
+        assertPropertyArray(headersAndValues, "User-Agent", "flink-connector-http");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSubmitterFactory")
+    public void shouldBuildClientWithUserAgentHeader(
+            RequestSubmitterFactory requestSubmitterFactory) {
+        // GIVEN
+        Properties properties = new Properties();
+        properties.setProperty("http.user.agent", "custom-sink-agent/2.0");
+
+        // WHEN
+        JavaNetSinkHttpClient client =
+                new JavaNetSinkHttpClient(
+                        properties,
+                        postRequestCallback,
+                        headerPreprocessor,
+                        requestSubmitterFactory);
+        String[] headersAndValues = client.getHeadersAndValues();
+
+        // THEN
+        assertThat(headersAndValues).hasSize(2);
+        assertPropertyArray(headersAndValues, "User-Agent", "custom-sink-agent/2.0");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSubmitterFactory")
+    public void shouldUseDefaultUserAgentWhenNotConfigured(
+            RequestSubmitterFactory requestSubmitterFactory) {
+        // GIVEN
+        Properties properties = new Properties();
+
+        // WHEN
+        JavaNetSinkHttpClient client =
+                new JavaNetSinkHttpClient(
+                        properties,
+                        postRequestCallback,
+                        headerPreprocessor,
+                        requestSubmitterFactory);
+        String[] headersAndValues = client.getHeadersAndValues();
+
+        // THEN
+        assertThat(headersAndValues).hasSize(2);
+        assertPropertyArray(headersAndValues, "User-Agent", "flink-connector-http");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSubmitterFactory")
+    public void shouldThrowErrorWhenUserAgentConflict(
+            RequestSubmitterFactory requestSubmitterFactory) {
+        // GIVEN
+        Properties properties = new Properties();
+        properties.setProperty("http.user.agent", "custom-agent");
+        properties.setProperty(
+                HttpConnectorConfigConstants.SINK_HEADER_PREFIX + "User-Agent", "header-agent");
+
+        // WHEN & THEN
+        assertThatThrownBy(
+                        () ->
+                                new JavaNetSinkHttpClient(
+                                        properties,
+                                        postRequestCallback,
+                                        headerPreprocessor,
+                                        requestSubmitterFactory))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("User-Agent header is set both explicitly");
     }
 }

--- a/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientTest.java
+++ b/flink-connector-http/src/test/java/org/apache/flink/connector/http/table/lookup/JavaNetHttpPollingClientTest.java
@@ -54,6 +54,7 @@ import java.util.Properties;
 import static org.apache.flink.connector.http.TestHelper.assertPropertyArray;
 import static org.apache.flink.connector.http.table.lookup.HttpLookupTableSourceFactory.row;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link JavaNetHttpPollingClient}. */
 @ExtendWith(MockitoExtension.class)
@@ -91,8 +92,11 @@ public class JavaNetHttpPollingClientTest {
                                 headerPreprocessor,
                                 options));
 
-        assertThat(((GetRequestFactory) client.getRequestFactory()).getHeadersAndValues())
-                .isEmpty();
+        String[] headers = ((GetRequestFactory) client.getRequestFactory()).getHeadersAndValues();
+        // By default, User-Agent header is always added with default value
+        assertThat(headers).hasSize(2);
+        assertThat(headers[0]).isEqualTo("User-Agent");
+        assertThat(headers[1]).isEqualTo("flink-connector-http");
     }
 
     @Test
@@ -225,7 +229,8 @@ public class JavaNetHttpPollingClientTest {
 
         String[] headersAndValues =
                 ((GetRequestFactory) client.getRequestFactory()).getHeadersAndValues();
-        assertThat(headersAndValues).hasSize(6);
+        // 3 custom headers + default User-Agent header = 8 total (4 pairs)
+        assertThat(headersAndValues).hasSize(8);
 
         // THEN
         // assert that we have property followed by its value.
@@ -235,6 +240,8 @@ public class JavaNetHttpPollingClientTest {
                 "Cache-Control",
                 "no-cache, no-store, max-age=0, must-revalidate");
         assertPropertyArray(headersAndValues, "Access-Control-Allow-Origin", "*");
+        // Default User-Agent header should also be present
+        assertPropertyArray(headersAndValues, "User-Agent", "flink-connector-http");
     }
 
     @Test
@@ -457,5 +464,83 @@ public class JavaNetHttpPollingClientTest {
         // THEN - only valid deserialization should be included
         assertThat(result).isNotNull();
         assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void shouldBuildClientWithUserAgentHeader() throws ConfigurationException {
+        // GIVEN
+        Configuration config = new Configuration();
+        config.setString(
+                HttpLookupConnectorOptions.SOURCE_LOOKUP_USER_AGENT.key(), "custom-agent/1.0");
+
+        HttpLookupConfig lookupConfig =
+                HttpLookupConfig.builder().url(BASE_URL).readableConfig(config).build();
+
+        // WHEN
+        JavaNetHttpPollingClient client =
+                new JavaNetHttpPollingClient(
+                        httpClient,
+                        decoder,
+                        lookupConfig,
+                        new GetRequestFactory(
+                                new GenericGetQueryCreator(lookupRow),
+                                headerPreprocessor,
+                                lookupConfig));
+
+        // THEN
+        String[] headers = ((GetRequestFactory) client.getRequestFactory()).getHeadersAndValues();
+        assertThat(headers).hasSize(2);
+        assertThat(headers[0]).isEqualTo("User-Agent");
+        assertThat(headers[1]).isEqualTo("custom-agent/1.0");
+    }
+
+    @Test
+    public void shouldUseDefaultUserAgentWhenNotConfigured() throws ConfigurationException {
+        // GIVEN
+        HttpLookupConfig lookupConfig = HttpLookupConfig.builder().url(BASE_URL).build();
+
+        // WHEN
+        JavaNetHttpPollingClient client =
+                new JavaNetHttpPollingClient(
+                        httpClient,
+                        decoder,
+                        lookupConfig,
+                        new GetRequestFactory(
+                                new GenericGetQueryCreator(lookupRow),
+                                headerPreprocessor,
+                                lookupConfig));
+
+        // THEN
+        String[] headers = ((GetRequestFactory) client.getRequestFactory()).getHeadersAndValues();
+        assertThat(headers).hasSize(2);
+        assertThat(headers[0]).isEqualTo("User-Agent");
+        assertThat(headers[1]).isEqualTo("flink-connector-http");
+    }
+
+    @Test
+    public void shouldThrowErrorWhenUserAgentConflict() {
+        // GIVEN
+        Properties properties = new Properties();
+        properties.setProperty("http.user.agent", "custom-agent");
+        properties.setProperty(
+                HttpConnectorConfigConstants.LOOKUP_SOURCE_HEADER_PREFIX + "User-Agent",
+                "header-agent");
+
+        HttpLookupConfig lookupConfig =
+                HttpLookupConfig.builder().url(BASE_URL).properties(properties).build();
+
+        // WHEN & THEN
+        assertThatThrownBy(
+                        () ->
+                                new JavaNetHttpPollingClient(
+                                        httpClient,
+                                        decoder,
+                                        lookupConfig,
+                                        new GetRequestFactory(
+                                                new GenericGetQueryCreator(lookupRow),
+                                                headerPreprocessor,
+                                                lookupConfig)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("User-Agent header is set both explicitly");
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Add a dedicated `http.user.agent` option so that requests issued by the
HTTP connector carry an identifiable `User-Agent` header out of the box,
for both the lookup source and the async sink.

Without this option, the underlying Java `HttpClient` sends requests
without any `User-Agent` header, which makes server-side logging,
rate limiting and access auditing harder. Users could already override
the header via `http.source.lookup.header.User-Agent` /
`http.sink.header.User-Agent`, but there was no sensible default.

## Brief change log

- Add `http.user.agent` ConfigOption to `HttpLookupConnectorOptions`
  and `HttpDynamicSinkConnectorOptions`. Default value is
  `flink-connector-http` (matches the connector artifact identifier).
- Apply the option in `RequestFactoryBase` (lookup) and
  `JavaNetSinkHttpClient` (sink).
- Reject setting `User-Agent` simultaneously via `http.user.agent` and
  via the corresponding `http.*.header.User-Agent` entry with a clear
  `IllegalArgumentException`.
- Register both `SINK_HEADERS` / `SOURCE_LOOKUP_HEADERS` (from
  FLINK-HTTP-3) and the new `USER_AGENT` option in the factory
  `optionalOptions()` lists.
- Document the new option in the lookup and sink options tables and
  add a short `User-Agent` subsection with an example DDL.
- Tests cover default value, custom value and the conflict path.

## Verifying this change

- `JavaNetSinkHttpClientTest#shouldBuildClientWithoutHeaders` now
  asserts that the default `User-Agent: flink-connector-http` is
  attached when no header configuration is given.
- `JavaNetSinkHttpClientTest#shouldBuildClientWithCustomUserAgent` and
  `JavaNetHttpPollingClientTest#shouldBuildClientWithCustomUserAgent`
  assert that a user-provided value is honoured.
- `JavaNetSinkHttpClientTest#shouldThrowErrorWhenUserAgentConflict`
  and the lookup counterpart assert that the conflict detection fires
  with a helpful message.

## Does this pull request potentially affect one of the following parts:

- Dependencies: no
- The public API: yes — new `http.user.agent` ConfigOption
- The runtime per-record code paths: only by attaching one extra
  header to outgoing requests
- Anything that affects deployment or recovery: no

## Documentation

- Does this pull request introduce a new feature: yes
- If yes, how is the feature documented: in
  `docs/content/docs/connectors/table/http.md` and the `content.zh`
  equivalent, under the lookup options table, sink options table and
  a dedicated `User-Agent` subsection
