### PR TITLE
[hotfix] Ignore unused dependancies for snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -644,10 +644,12 @@ under the License.
                             <ignoredDependencies>
                                 <!--These dependencies are required for the unit tests to succeed  -->
                                 <ignoredDependency>org.mockito:mockito-inline:jar:4.6.1</ignoredDependency>
-                                <!-- Runtime dependencies loaded via ServiceLoader for test execution -->
-                                <ignoredDependency>org.apache.flink:flink-clients:jar:*:test</ignoredDependency>
-                                <ignoredDependency>org.apache.flink:flink-streaming-java:jar:*:test</ignoredDependency>
                             </ignoredDependencies>
+                            <ignoredUnusedDeclaredDependencies>
+                                <!-- Runtime dependencies loaded via ServiceLoader for test execution -->
+                                <ignoredUnusedDeclaredDependency>org.apache.flink:flink-clients</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.apache.flink:flink-streaming-java</ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
In the maven build there are some runtime dependancies that are ignored, as they are brought in via the service loader.
The weekly checks runs against the  snapshot version of Flink 2.2, but the ignore dependancies was not working for snapshot builds. This change changes the code to ignore unused dependancies, which works for snapshot and non snapshots.  